### PR TITLE
Stop using repo_name

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,12 +1,11 @@
 module(
     name = "rules_jsonnet",
     version = "0.6.0",
-    repo_name = "io_bazel_rules_jsonnet",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "jsonnet", version = "0.20.0")
-bazel_dep(name = "jsonnet_go", version = "0.20.0", repo_name = "google_jsonnet_go")
+bazel_dep(name = "jsonnet_go", version = "0.20.0")
 bazel_dep(name = "rules_rust", version = "0.50.1")
 
 jsonnet = use_extension("//jsonnet:extensions.bzl", "jsonnet")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,11 +7,11 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "jsonnet", version = "0.20.0")
 bazel_dep(name = "jsonnet_go", version = "0.20.0", repo_name = "google_jsonnet_go")
-
 bazel_dep(name = "rules_rust", version = "0.50.1")
 
 jsonnet = use_extension("//jsonnet:extensions.bzl", "jsonnet")
 use_repo(jsonnet, "rules_jsonnet_toolchain")
+
 register_toolchains("@rules_jsonnet_toolchain//:toolchain")
 
 rust_host = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
@@ -22,10 +22,6 @@ rust_host.host_tools(
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
     edition = "2021",
-    # Nightly version is required to be able to depend on a binary dependency
-    # with Cargo.
-    # See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies.
-    versions = ["nightly/2024-05-01"],
     sha256s = {
         "2024-05-01/rustc-nightly-aarch64-apple-darwin.tar.xz": "3c3d4693b8e846c9c250bb14a97654657ca62a5eb20617a875c34462582daf83",
         "2024-05-01/clippy-nightly-aarch64-apple-darwin.tar.xz": "379e22e343a7b1c2e39b030810ff633d800d0daae0f8fd6bf00181402c42be4e",
@@ -33,18 +29,22 @@ rust.toolchain(
         "2024-05-01/llvm-tools-nightly-aarch64-apple-darwin.tar.xz": "4b04ceaf724bea888fb1e5e6bd9a9a963196f585d4f73036e783a2c51d4e907e",
         "2024-05-01/rust-std-nightly-aarch64-apple-darwin.tar.xz": "bf52ea3e1ac669455694079fb83b6bd0d446e759b9ab3502f75615d538e646a0",
     },
+    # Nightly version is required to be able to depend on a binary dependency
+    # with Cargo.
+    # See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#artifact-dependencies.
+    versions = ["nightly/2024-05-01"],
 )
-
 use_repo(rust, "rust_toolchains")
+
 register_toolchains("@rust_toolchains//:all")
 
 crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
 crate.spec(
-    package = "jrsonnet",
-    version = "0.5.0-pre95",
     # Binary artifacts can't be depended upon without specifically marking the
     # artifact as `bin`.
     artifact = "bin",
+    package = "jrsonnet",
+    version = "0.5.0-pre95",
 )
 
 # Required for rules_rust to generate binary targets for the Jrsonnet crate.

--- a/docs/jsonnet.md
+++ b/docs/jsonnet.md
@@ -41,7 +41,7 @@ Example:
   `configs/BUILD`:
 
   ```python
-  load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library")
+  load("@rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library")
 
   jsonnet_library(
       name = "configs",
@@ -104,7 +104,7 @@ Example:
   `workflows/BUILD`:
 
   ```python
-  load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library")
+  load("@rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library")
 
   jsonnet_library(
       name = "workflow",
@@ -260,7 +260,7 @@ Example:
 
   ```python
   load(
-      "@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl",
+      "@rules_jsonnet//jsonnet:jsonnet.bzl",
       "jsonnet_library",
       "jsonnet_to_json_test",
   )
@@ -308,7 +308,7 @@ Example:
 
   ```python
   load(
-      "@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl",
+      "@rules_jsonnet//jsonnet:jsonnet.bzl",
       "jsonnet_library",
       "jsonnet_to_json_test",
   )

--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -41,7 +41,7 @@ jsonnet_toolchain(
 
 jsonnet_toolchain(
     name = "go_jsonnet",
-    compiler = "@google_jsonnet_go//cmd/jsonnet",
+    compiler = "@jsonnet_go//cmd/jsonnet",
     create_directory_flags = ["-c"],
     manifest_file_support = True,
 )

--- a/jsonnet/extensions.bzl
+++ b/jsonnet/extensions.bzl
@@ -54,7 +54,7 @@ def _jsonnet_toolchain_repo_impl(ctx):
         content = """
 alias(
     name = "toolchain",
-    actual = "@io_bazel_rules_jsonnet//jsonnet:%s_jsonnet_toolchain",
+    actual = "@rules_jsonnet//jsonnet:%s_jsonnet_toolchain",
 )
 """ % ctx.attr.compiler,
         executable = False,

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -511,7 +511,7 @@ Example:
   `configs/BUILD`:
 
   ```python
-  load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library")
+  load("@rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library")
 
   jsonnet_library(
       name = "configs",
@@ -662,7 +662,7 @@ Example:
   `workflows/BUILD`:
 
   ```python
-  load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library")
+  load("@rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library")
 
   jsonnet_library(
       name = "workflow",
@@ -802,7 +802,7 @@ Example:
 
   ```python
   load(
-      "@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl",
+      "@rules_jsonnet//jsonnet:jsonnet.bzl",
       "jsonnet_library",
       "jsonnet_to_json_test",
   )
@@ -850,7 +850,7 @@ Example:
 
   ```python
   load(
-      "@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl",
+      "@rules_jsonnet//jsonnet:jsonnet.bzl",
       "jsonnet_library",
       "jsonnet_to_json_test",
   )


### PR DESCRIPTION
Now that support for WORKSPACE has been removed, we can refer to modules using the original names.