### PR TITLE
fix: restore default outputs of jsonnet_to_json

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -240,6 +240,19 @@ jsonnet_to_json_test(
     deps = ["//imports:a"],
 )
 
+jsonnet_library(
+    name = "imports_default_output",
+    srcs = [":imports_build"],
+)
+
+jsonnet_to_json_test(
+    name = "imports_default_output_test",
+    src = "imports_default_output.jsonnet",
+    golden = "imports_golden.json",
+    imports = ["imports"],
+    deps = [":imports_default_output"],
+)
+
 jsonnet_to_json_test(
     name = "strings_test",
     src = "strings.jsonnet",

--- a/examples/imports_default_output.jsonnet
+++ b/examples/imports_default_output.jsonnet
@@ -1,0 +1,1 @@
+import 'imports.json'

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -289,8 +289,8 @@ def _jsonnet_to_json_impl(ctx):
         )]
 
     return [DefaultInfo(
-        files = depset([]),
-        runfiles = ctx.runfiles(files = []),
+        files = depset(outputs),
+        runfiles = ctx.runfiles(files = outputs),
     )]
 
 _EXIT_CODE_COMPARE_COMMAND = """


### PR DESCRIPTION
This PR restores the default outputs of the `jsonnet_to_json` rule.

PR #192 seems to have broken the default outputs of this rule, which previously relied on only setting `ctx.outputs` and not returning a `DefaultInfo` provider (unless `out_dir` is set).

This is useful when you have some target that only has one output e.g.:
```starlark
jsonnet_to_json(
    name = "foo",
    src = "foo.jsonnet",
    outs = ["foo.json"],
)
```

Before #192 you could depend on this as `:foo`, but after #192 you need to depend on `:foo.json` to access the singular output.