### PR TITLE
fix(rust): added name to the rust host_tools definition to avoid conf…

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "jsonnet", version = "0.20.0")
 bazel_dep(name = "jsonnet_go", version = "0.20.0")
-bazel_dep(name = "rules_rust", version = "0.54.1")
+bazel_dep(name = "rules_rust", version = "0.57.1")
 
 jsonnet = use_extension("//jsonnet:extensions.bzl", "jsonnet")
 use_repo(jsonnet, "rules_jsonnet_toolchain")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,7 @@ register_toolchains("@rules_jsonnet_toolchain//:toolchain")
 
 rust_host = use_extension("@rules_rust//rust:extensions.bzl", "rust_host_tools")
 rust_host.host_tools(
+    name = "rust_host_tools_jsonnet",
     version = "nightly/2024-05-02",
 )
 


### PR DESCRIPTION
This PR simply adds a name to the host_tools repo so that it won't conflict with the default one used within `rules_rust`

# Important

This will work when `rules_rust` tags the next version (at the time of writing is 0.56.0) and after we bump it here.

It works on my setup since I am relying on a `local_path_override` to the latest HEAD, which includes the `name` attribute CI is currently complaining about.

I'll update this PR accordingly when the time comes

Fixes #228 