### PR TITLE
Get py_binary() from @rules_python

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "jsonnet", version = "0.20.0")
 bazel_dep(name = "jsonnet_go", version = "0.20.0")
+bazel_dep(name = "rules_python", version = "1.2.0")
 bazel_dep(name = "rules_rust", version = "0.54.1")
 
 jsonnet = use_extension("//jsonnet:extensions.bzl", "jsonnet")

--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -1,4 +1,5 @@
 load(":toolchain.bzl", "jsonnet_toolchain")
+load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(["docs.bzl", "jsonnet.bzl", "toolchain.bzl"])


### PR DESCRIPTION
In the future the Python rules will be removed from Bazel itself.