### PR TITLE
fix: default crates_universe name collision in Bazel module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,6 +52,7 @@ crate.annotation(
     gen_binaries = ["jrsonnet"],
 )
 crate.from_specs(
+    name = "crates_jsonnet",
     host_tools = "@rust_host_tools_jsonnet",
 )
-use_repo(crate, "crates")
+use_repo(crate, "crates_jsonnet")

--- a/jsonnet/BUILD
+++ b/jsonnet/BUILD
@@ -35,7 +35,7 @@ toolchain_type(name = "toolchain_type")
 
 jsonnet_toolchain(
     name = "rust_jsonnet",
-    compiler = "@crates//:jrsonnet__jrsonnet",
+    compiler = "@crates_jsonnet//:jrsonnet__jrsonnet",
     create_directory_flags = ["-c"],
     manifest_file_support = False,
 )


### PR DESCRIPTION
If this Bazel module is used as a dependency of another module which also uses `rules_rust`'s `crate_universe` extension with the default name (`crates`), it will fail with an error like:
```
ERROR: /redacted/external/rules_rust+/crate_universe/extensions.bzl:941:21: Traceback (most recent call last):
        File "/redacted/external/rules_rust+/crate_universe/extensions.bzl", line 941, column 21, in _crate_impl
                fail("Defined two crate universes with the same name in different MODULE.bazel files (`{}`). Either give one a different name, or use `use_extension(isolate=True)`".format(
Error in fail: Defined two crate universes with the same name in different MODULE.bazel files (`crates`). Either give one a different name, or use `use_extension(isolate=True)`
```
The error's suggested fix of isolating the `rules_jsonnet` extension is not possible, since the problem is in `@rules_jsonnet` (i.e. the extension's root repo, not one included via `use_repo()`).

To avoid this, I've renamed the `crate_universe` repo to `crates_jsonnet`, following the convention used for `rust_host_tools_jsonnet`.

I'm not really sure how best to add a test for this, but I am open to suggestions.