### PR TITLE
Support for `jsonnet_library` as code files to `jsonnet_to_json{,_test}` rules

### DIFF
--- a/docs/jsonnet.md
+++ b/docs/jsonnet.md
@@ -198,7 +198,7 @@ Example:
 | <a id="jsonnet_to_json-ext_code_envs"></a>ext_code_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-ext_code_file_vars"></a>ext_code_file_vars |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-ext_code_files"></a>ext_code_files |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="jsonnet_to_json-ext_code_libraries"></a>ext_code_libraries |  Include jsonnet_library as a extvar with the key value   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
+| <a id="jsonnet_to_json-ext_code_libraries"></a>ext_code_libraries |  Include jsonnet_library as an extvar with the key value   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json-ext_str_envs"></a>ext_str_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-ext_str_file_vars"></a>ext_str_file_vars |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-ext_str_files"></a>ext_str_files |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
@@ -349,7 +349,7 @@ Example:
 | <a id="jsonnet_to_json_test-ext_code_envs"></a>ext_code_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-ext_code_file_vars"></a>ext_code_file_vars |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-ext_code_files"></a>ext_code_files |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="jsonnet_to_json_test-ext_code_libraries"></a>ext_code_libraries |  Include jsonnet_library as a extvar with the key value   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
+| <a id="jsonnet_to_json_test-ext_code_libraries"></a>ext_code_libraries |  Include jsonnet_library as an extvar with the key value   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json_test-ext_str_envs"></a>ext_str_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-ext_str_file_vars"></a>ext_str_file_vars |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-ext_str_files"></a>ext_str_files |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |

--- a/docs/jsonnet.md
+++ b/docs/jsonnet.md
@@ -72,9 +72,10 @@ Example:
 load("@rules_jsonnet//jsonnet:docs.bzl", "jsonnet_to_json")
 
 jsonnet_to_json(<a href="#jsonnet_to_json-name">name</a>, <a href="#jsonnet_to_json-deps">deps</a>, <a href="#jsonnet_to_json-src">src</a>, <a href="#jsonnet_to_json-data">data</a>, <a href="#jsonnet_to_json-outs">outs</a>, <a href="#jsonnet_to_json-code_vars">code_vars</a>, <a href="#jsonnet_to_json-ext_code">ext_code</a>, <a href="#jsonnet_to_json-ext_code_envs">ext_code_envs</a>, <a href="#jsonnet_to_json-ext_code_file_vars">ext_code_file_vars</a>,
-                <a href="#jsonnet_to_json-ext_code_files">ext_code_files</a>, <a href="#jsonnet_to_json-ext_str_envs">ext_str_envs</a>, <a href="#jsonnet_to_json-ext_str_file_vars">ext_str_file_vars</a>, <a href="#jsonnet_to_json-ext_str_files">ext_str_files</a>, <a href="#jsonnet_to_json-ext_strs">ext_strs</a>, <a href="#jsonnet_to_json-extra_args">extra_args</a>,
-                <a href="#jsonnet_to_json-imports">imports</a>, <a href="#jsonnet_to_json-multiple_outputs">multiple_outputs</a>, <a href="#jsonnet_to_json-out_dir">out_dir</a>, <a href="#jsonnet_to_json-stamp_keys">stamp_keys</a>, <a href="#jsonnet_to_json-tla_code">tla_code</a>, <a href="#jsonnet_to_json-tla_code_envs">tla_code_envs</a>,
-                <a href="#jsonnet_to_json-tla_code_files">tla_code_files</a>, <a href="#jsonnet_to_json-tla_str_envs">tla_str_envs</a>, <a href="#jsonnet_to_json-tla_str_files">tla_str_files</a>, <a href="#jsonnet_to_json-tla_strs">tla_strs</a>, <a href="#jsonnet_to_json-vars">vars</a>, <a href="#jsonnet_to_json-yaml_stream">yaml_stream</a>)
+                <a href="#jsonnet_to_json-ext_code_files">ext_code_files</a>, <a href="#jsonnet_to_json-ext_code_libraries">ext_code_libraries</a>, <a href="#jsonnet_to_json-ext_str_envs">ext_str_envs</a>, <a href="#jsonnet_to_json-ext_str_file_vars">ext_str_file_vars</a>, <a href="#jsonnet_to_json-ext_str_files">ext_str_files</a>,
+                <a href="#jsonnet_to_json-ext_strs">ext_strs</a>, <a href="#jsonnet_to_json-extra_args">extra_args</a>, <a href="#jsonnet_to_json-imports">imports</a>, <a href="#jsonnet_to_json-multiple_outputs">multiple_outputs</a>, <a href="#jsonnet_to_json-out_dir">out_dir</a>, <a href="#jsonnet_to_json-stamp_keys">stamp_keys</a>, <a href="#jsonnet_to_json-tla_code">tla_code</a>,
+                <a href="#jsonnet_to_json-tla_code_envs">tla_code_envs</a>, <a href="#jsonnet_to_json-tla_code_files">tla_code_files</a>, <a href="#jsonnet_to_json-tla_code_libraries">tla_code_libraries</a>, <a href="#jsonnet_to_json-tla_str_envs">tla_str_envs</a>, <a href="#jsonnet_to_json-tla_str_files">tla_str_files</a>,
+                <a href="#jsonnet_to_json-tla_strs">tla_strs</a>, <a href="#jsonnet_to_json-vars">vars</a>, <a href="#jsonnet_to_json-yaml_stream">yaml_stream</a>)
 </pre>
 
 Compiles Jsonnet code to JSON.
@@ -197,6 +198,7 @@ Example:
 | <a id="jsonnet_to_json-ext_code_envs"></a>ext_code_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-ext_code_file_vars"></a>ext_code_file_vars |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-ext_code_files"></a>ext_code_files |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="jsonnet_to_json-ext_code_libraries"></a>ext_code_libraries |  Include jsonnet_library as a extvar with the key value   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json-ext_str_envs"></a>ext_str_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-ext_str_file_vars"></a>ext_str_file_vars |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-ext_str_files"></a>ext_str_files |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
@@ -209,6 +211,7 @@ Example:
 | <a id="jsonnet_to_json-tla_code"></a>tla_code |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json-tla_code_envs"></a>tla_code_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-tla_code_files"></a>tla_code_files |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
+| <a id="jsonnet_to_json-tla_code_libraries"></a>tla_code_libraries |  Include jsonnet_library as a top-level argument as the given value   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json-tla_str_envs"></a>tla_str_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json-tla_str_files"></a>tla_str_files |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json-tla_strs"></a>tla_strs |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
@@ -224,10 +227,11 @@ Example:
 load("@rules_jsonnet//jsonnet:docs.bzl", "jsonnet_to_json_test")
 
 jsonnet_to_json_test(<a href="#jsonnet_to_json_test-name">name</a>, <a href="#jsonnet_to_json_test-deps">deps</a>, <a href="#jsonnet_to_json_test-src">src</a>, <a href="#jsonnet_to_json_test-data">data</a>, <a href="#jsonnet_to_json_test-canonicalize_golden">canonicalize_golden</a>, <a href="#jsonnet_to_json_test-code_vars">code_vars</a>, <a href="#jsonnet_to_json_test-error">error</a>, <a href="#jsonnet_to_json_test-ext_code">ext_code</a>,
-                     <a href="#jsonnet_to_json_test-ext_code_envs">ext_code_envs</a>, <a href="#jsonnet_to_json_test-ext_code_file_vars">ext_code_file_vars</a>, <a href="#jsonnet_to_json_test-ext_code_files">ext_code_files</a>, <a href="#jsonnet_to_json_test-ext_str_envs">ext_str_envs</a>,
-                     <a href="#jsonnet_to_json_test-ext_str_file_vars">ext_str_file_vars</a>, <a href="#jsonnet_to_json_test-ext_str_files">ext_str_files</a>, <a href="#jsonnet_to_json_test-ext_strs">ext_strs</a>, <a href="#jsonnet_to_json_test-extra_args">extra_args</a>, <a href="#jsonnet_to_json_test-golden">golden</a>, <a href="#jsonnet_to_json_test-imports">imports</a>,
-                     <a href="#jsonnet_to_json_test-output_file_contents">output_file_contents</a>, <a href="#jsonnet_to_json_test-regex">regex</a>, <a href="#jsonnet_to_json_test-stamp_keys">stamp_keys</a>, <a href="#jsonnet_to_json_test-tla_code">tla_code</a>, <a href="#jsonnet_to_json_test-tla_code_envs">tla_code_envs</a>, <a href="#jsonnet_to_json_test-tla_code_files">tla_code_files</a>,
-                     <a href="#jsonnet_to_json_test-tla_str_envs">tla_str_envs</a>, <a href="#jsonnet_to_json_test-tla_str_files">tla_str_files</a>, <a href="#jsonnet_to_json_test-tla_strs">tla_strs</a>, <a href="#jsonnet_to_json_test-vars">vars</a>, <a href="#jsonnet_to_json_test-yaml_stream">yaml_stream</a>)
+                     <a href="#jsonnet_to_json_test-ext_code_envs">ext_code_envs</a>, <a href="#jsonnet_to_json_test-ext_code_file_vars">ext_code_file_vars</a>, <a href="#jsonnet_to_json_test-ext_code_files">ext_code_files</a>, <a href="#jsonnet_to_json_test-ext_code_libraries">ext_code_libraries</a>,
+                     <a href="#jsonnet_to_json_test-ext_str_envs">ext_str_envs</a>, <a href="#jsonnet_to_json_test-ext_str_file_vars">ext_str_file_vars</a>, <a href="#jsonnet_to_json_test-ext_str_files">ext_str_files</a>, <a href="#jsonnet_to_json_test-ext_strs">ext_strs</a>, <a href="#jsonnet_to_json_test-extra_args">extra_args</a>, <a href="#jsonnet_to_json_test-golden">golden</a>,
+                     <a href="#jsonnet_to_json_test-imports">imports</a>, <a href="#jsonnet_to_json_test-output_file_contents">output_file_contents</a>, <a href="#jsonnet_to_json_test-regex">regex</a>, <a href="#jsonnet_to_json_test-stamp_keys">stamp_keys</a>, <a href="#jsonnet_to_json_test-tla_code">tla_code</a>, <a href="#jsonnet_to_json_test-tla_code_envs">tla_code_envs</a>,
+                     <a href="#jsonnet_to_json_test-tla_code_files">tla_code_files</a>, <a href="#jsonnet_to_json_test-tla_code_libraries">tla_code_libraries</a>, <a href="#jsonnet_to_json_test-tla_str_envs">tla_str_envs</a>, <a href="#jsonnet_to_json_test-tla_str_files">tla_str_files</a>, <a href="#jsonnet_to_json_test-tla_strs">tla_strs</a>, <a href="#jsonnet_to_json_test-vars">vars</a>,
+                     <a href="#jsonnet_to_json_test-yaml_stream">yaml_stream</a>)
 </pre>
 
 Compiles Jsonnet code to JSON and checks the output.
@@ -345,6 +349,7 @@ Example:
 | <a id="jsonnet_to_json_test-ext_code_envs"></a>ext_code_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-ext_code_file_vars"></a>ext_code_file_vars |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-ext_code_files"></a>ext_code_files |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="jsonnet_to_json_test-ext_code_libraries"></a>ext_code_libraries |  Include jsonnet_library as a extvar with the key value   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json_test-ext_str_envs"></a>ext_str_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-ext_str_file_vars"></a>ext_str_file_vars |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-ext_str_files"></a>ext_str_files |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
@@ -358,6 +363,7 @@ Example:
 | <a id="jsonnet_to_json_test-tla_code"></a>tla_code |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json_test-tla_code_envs"></a>tla_code_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-tla_code_files"></a>tla_code_files |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
+| <a id="jsonnet_to_json_test-tla_code_libraries"></a>tla_code_libraries |  Include jsonnet_library as a top-level argument as the given value   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json_test-tla_str_envs"></a>tla_str_envs |  -   | List of strings | optional |  `[]`  |
 | <a id="jsonnet_to_json_test-tla_str_files"></a>tla_str_files |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: Label -> String</a> | optional |  `{}`  |
 | <a id="jsonnet_to_json_test-tla_strs"></a>tla_strs |  -   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -117,6 +117,28 @@ jsonnet_to_json_test(
     golden = "extvar_files_golden.json",
 )
 
+jsonnet_library(
+    name = "code_library_lib",
+    srcs = ["code_library.libsonnet"],
+    deps = [":workflow"]
+)
+
+jsonnet_to_json_test(
+    name = "extvar_code_library_test",
+    size = "small",
+    src = "extvar_code_library.jsonnet",
+    ext_code_libraries = { ":code_library_lib": "codefile" },
+    golden = "extvar_files_library_golden.json",
+)
+
+jsonnet_to_json_test(
+    name = "tla_code_library_test",
+    size = "small",
+    src = "tla_code_library.jsonnet",
+    tla_code_libraries = { ":code_library_lib": "tla_code" },
+    golden = "tla_code_library_golden.json",
+)
+
 jsonnet_to_json_test(
     name = "tla_code_files_test",
     size = "small",

--- a/examples/code_library.libsonnet
+++ b/examples/code_library.libsonnet
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Re-export depdencies for depedency injection
+// Re-export dependencies for dependency inversion
 {
   workflow: import 'workflow.libsonnet',
 }

--- a/examples/code_library.libsonnet
+++ b/examples/code_library.libsonnet
@@ -1,0 +1,18 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Re-export depdencies for depedency injection
+{
+  workflow: import 'workflow.libsonnet',
+}

--- a/examples/extvar_code_library.jsonnet
+++ b/examples/extvar_code_library.jsonnet
@@ -1,0 +1,6 @@
+local codefile = std.extVar('codefile');
+
+{
+  job: codefile.workflow.Job,
+  shJob: codefile.workflow.ShJob,
+}

--- a/examples/extvar_files_library_golden.json
+++ b/examples/extvar_files_library_golden.json
@@ -1,0 +1,16 @@
+{
+   "job": {
+      "deps": [ ],
+      "inputs": [ ],
+      "outputs": [ ],
+      "type": "base"
+   },
+   "shJob": {
+      "command": "",
+      "deps": [ ],
+      "inputs": [ ],
+      "outputs": [ ],
+      "type": "sh",
+      "vars": { }
+   }
+}

--- a/examples/tla_code_library.jsonnet
+++ b/examples/tla_code_library.jsonnet
@@ -1,0 +1,3 @@
+function(tla_code) {
+  tla_code_contents: tla_code.workflow.Job,
+}

--- a/examples/tla_code_library_golden.json
+++ b/examples/tla_code_library_golden.json
@@ -1,0 +1,9 @@
+{
+   "tla_code_contents": {
+      "deps": [],
+      "inputs": [],
+      "outputs": [],
+      "type": "base"
+   }
+}
+

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -22,12 +22,11 @@ _JSONNET_FILETYPE = [
 
 JsonnetLibraryInfo = provider(
     fields = {
-        'imports': 'Depset of Strings containing import flags set by transitive dependency targets.',
-        'short_imports': 'Depset of Strings containing import flags set by transitive dependency targets, when invoking Jsonnet as part of a test where dependencies are stored in runfiles.',
-        'transitive_jsonnet_files': 'Depset of Files containing sources of transitive dependencies',
-    }
+        "imports": "Depset of Strings containing import flags set by transitive dependency targets.",
+        "short_imports": "Depset of Strings containing import flags set by transitive dependency targets, when invoking Jsonnet as part of a test where dependencies are stored in runfiles.",
+        "transitive_jsonnet_files": "Depset of Files containing sources of transitive dependencies",
+    },
 )
-
 
 def _get_import_paths(label, files, imports, short_path):
     # TODO: Is there a cleaner way to compute the short paths here?
@@ -52,7 +51,7 @@ def _get_import_paths(label, files, imports, short_path):
         for im in imports
     ]
 
-def _setup_deps(deps, tla_code_libraries={}, ext_code_libraries={}):
+def _setup_deps(deps, tla_code_libraries = {}, ext_code_libraries = {}):
     """Collects source files and import flags of transitive dependencies.
 
     Args:
@@ -600,7 +599,7 @@ _jsonnet_compile_attrs = {
         allow_files = True,
     ),
     "ext_code_libraries": attr.label_keyed_string_dict(
-        doc = "Include jsonnet_library as a extvar with the key value",
+        doc = "Include jsonnet_library as an extvar with the key value",
         providers = [JsonnetLibraryInfo],
     ),
     "ext_str_envs": attr.string_list(),

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -203,10 +203,10 @@ def _jsonnet_to_json_impl(ctx):
     stamp_inputs = strs_stamp_inputs + code_stamp_inputs + tla_strs_stamp_inputs + tla_code_stamp_inputs
 
     if len(jsonnet_ext_str_file_vars) != len(jsonnet_ext_str_files):
-        fail("Mistach of ext_str_file_vars ({}) to ext_str_files ({})".format(jsonnet_ext_str_file_vars, jsonnet_ext_str_files))
+        fail("Mismatch of ext_str_file_vars ({}) to ext_str_files ({})".format(jsonnet_ext_str_file_vars, jsonnet_ext_str_files))
 
     if len(jsonnet_ext_code_file_vars) != len(jsonnet_ext_code_files):
-        fail("Mistach of ext_code_file_vars ({}) to ext_code_files ({})".format(jsonnet_ext_code_file_vars, jsonnet_ext_code_files))
+        fail("Mismatch of ext_code_file_vars ({}) to ext_code_files ({})".format(jsonnet_ext_code_file_vars, jsonnet_ext_code_files))
 
     if ctx.attr.stamp_keys and not stamp_inputs:
         fail("Stamping requested but found no stamp variable to resolve for.")
@@ -248,7 +248,7 @@ def _jsonnet_to_json_impl(ctx):
         ["--tla-code-file %s=%s" %
          (var, jfile.files.to_list()[0].path) for jfile, var in jsonnet_tla_code_files.items()] +
         ["--tla-code-file %s=%s" %
-         (_quote(val),_quote(key[DefaultInfo].files.to_list()[0].path)) for key, val in jsonnet_tla_code_libraries.items()]
+         (_quote(val), _quote(key[DefaultInfo].files.to_list()[0].path)) for key, val in jsonnet_tla_code_libraries.items()]
     )
 
     outputs = []
@@ -437,10 +437,10 @@ def _jsonnet_to_json_test_impl(ctx):
     stamp_inputs = strs_stamp_inputs + code_stamp_inputs + tla_strs_stamp_inputs + tla_code_stamp_inputs
 
     if len(jsonnet_ext_str_file_vars) != len(jsonnet_ext_str_files):
-        fail("Mistach of ext_str_file_vars ({}) to ext_str_files ({})".format(jsonnet_ext_str_file_vars, jsonnet_ext_str_files))
+        fail("Mismatch of ext_str_file_vars ({}) to ext_str_files ({})".format(jsonnet_ext_str_file_vars, jsonnet_ext_str_files))
 
     if len(jsonnet_ext_code_file_vars) != len(jsonnet_ext_code_files):
-        fail("Mistach of ext_code_file_vars ({}) to ext_code_files ({})".format(jsonnet_ext_code_file_vars, jsonnet_ext_code_files))
+        fail("Mismatch of ext_code_file_vars ({}) to ext_code_files ({})".format(jsonnet_ext_code_file_vars, jsonnet_ext_code_files))
 
     other_args = ctx.attr.extra_args + (["-y"] if ctx.attr.yaml_stream else [])
     jsonnet_command = " ".join(
@@ -461,7 +461,7 @@ def _jsonnet_to_json_test_impl(ctx):
         ["--ext-code-file %s=%s" %
          (var, jfile.short_path) for var, jfile in zip(jsonnet_ext_code_file_vars, jsonnet_ext_code_files)] +
         ["--ext-code-file %s=%s" %
-         (_quote(val), _quote(key[DefaultInfo].files.to_list()[0].path)) for key, val in jsonnet_ext_code_libraries.items()] +
+         (_quote(val), _quote(key[DefaultInfo].files.to_list()[0].short_path)) for key, val in jsonnet_ext_code_libraries.items()] +
         ["--tla-str %s=%s" %
          (_quote(key), _quote(val)) for key, val in jsonnet_tla_strs.items()] +
         ["--tla-str '%s'" %
@@ -471,11 +471,11 @@ def _jsonnet_to_json_test_impl(ctx):
         ["--tla-code %s" %
          tla_code_env for tla_code_env in jsonnet_tla_code_envs] +
         ["--tla-str-file %s=%s" %
-         (var, jfile.files.to_list()[0].path) for jfile, var in jsonnet_tla_str_files.items()] +
+         (var, jfile.files.to_list()[0].short_path) for jfile, var in jsonnet_tla_str_files.items()] +
         ["--tla-code-file %s=%s" %
-         (var, jfile.files.to_list()[0].path) for jfile, var in jsonnet_tla_code_files.items()] +
+         (var, jfile.files.to_list()[0].short_path) for jfile, var in jsonnet_tla_code_files.items()] +
         ["--tla-code-file %s=%s" %
-         (_quote(val), _quote(key[DefaultInfo].files.to_list()[0].path)) for key, val in jsonnet_tla_code_libraries.items()] +
+         (_quote(val), _quote(key[DefaultInfo].files.to_list()[0].short_path)) for key, val in jsonnet_tla_code_libraries.items()] +
         [
             ctx.file.src.short_path,
             "2>&1)",

--- a/jsonnet/jsonnet.bzl
+++ b/jsonnet/jsonnet.bzl
@@ -202,6 +202,12 @@ def _jsonnet_to_json_impl(ctx):
     jsonnet_tla_code, tla_code_stamp_inputs = _make_stamp_resolve(ctx.attr.tla_code, ctx, False)
     stamp_inputs = strs_stamp_inputs + code_stamp_inputs + tla_strs_stamp_inputs + tla_code_stamp_inputs
 
+    if len(jsonnet_ext_str_file_vars) != len(jsonnet_ext_str_files):
+        fail("Mistach of ext_str_file_vars ({}) to ext_str_files ({})".format(jsonnet_ext_str_file_vars, jsonnet_ext_str_files))
+
+    if len(jsonnet_ext_code_file_vars) != len(jsonnet_ext_code_files):
+        fail("Mistach of ext_code_file_vars ({}) to ext_code_files ({})".format(jsonnet_ext_code_file_vars, jsonnet_ext_code_files))
+
     if ctx.attr.stamp_keys and not stamp_inputs:
         fail("Stamping requested but found no stamp variable to resolve for.")
 
@@ -431,7 +437,7 @@ def _jsonnet_to_json_test_impl(ctx):
     stamp_inputs = strs_stamp_inputs + code_stamp_inputs + tla_strs_stamp_inputs + tla_code_stamp_inputs
 
     if len(jsonnet_ext_str_file_vars) != len(jsonnet_ext_str_files):
-        fail("Mistach of ext_code_file_vars ({}) to ext_code_files ({})".format(jsonnet_ext_code_file_vars, jsonnet_ext_code_files))
+        fail("Mistach of ext_str_file_vars ({}) to ext_str_files ({})".format(jsonnet_ext_str_file_vars, jsonnet_ext_str_files))
 
     if len(jsonnet_ext_code_file_vars) != len(jsonnet_ext_code_files):
         fail("Mistach of ext_code_file_vars ({}) to ext_code_files ({})".format(jsonnet_ext_code_file_vars, jsonnet_ext_code_files))


### PR DESCRIPTION
# Context

I have been experimenting with dependency inversion with Jsonnet for Kubernetes manifests for many clusters and have been experimenting with using `ext_code_file` & `tla_code_file` but ran into the limitation that they do not pass on their dependency trees. 

I've got an example repo linked below that is using this pattern.

# Intent

This PR adds two new attributes to the `jsonnet_to_json` and `jsonnet_to_json_test`

```starlark
ext_code_libraries = {
  ":jsonnet_lib": "ext_name",
}
```

and 

```starlark
tla_code_libraries = {
  ":jsonnet_lib": "tla_name",
}
```

Both take a label that provides the `JsonnetLibraryInfo` and adds them to transitive dependencies. Their values are used as keys in the resulting `--ext-code-file` & `--tla-code-file` arguments just like the `tla_code_files`.

## Design

I've opted to create new attributes as I had initially tried to add support for `JsonnetLibraryInfo` to the existing `{ext,tla}_code_files` attributes but found it complicated them a lot with having a mix of files & `JsonnetLibraryInfo` providers logic.

### Known Limitation

If the library has more than 1 entry in `srcs` it will only pick the first in the list.

## Other changes

To ensure only the `srcs` are passed to the `--{ext,tla}-code-file` arguments I've modify `jsonnet_library` to returns a `DefaultInfo.files` of the `srcs`.

I've also updated `_setup_deps` to return a `JsonnetLibraryInfo` for consistency of field names  & copied over the docs to the provider.

During this change I ran into problems with mismatched `ext_{str,code}_file_vars` to `ext_{str,code}_files` and added an assertion for it.

# Example of usage

Example repo using current `rules_jsonnet`: https://github.com/dbanetto/bzl-jsonnet-pipeline using `ext_code_files`. In particular the usage of [`ext_code_files` can be found here](https://github.com/dbanetto/bzl-jsonnet-pipeline/blob/main/pipeline.bzl#L196-L217) which requires additional `deps` to be added if the given code file has extra deps.

Changes based off this PR: https://github.com/dbanetto/bzl-jsonnet-pipeline/compare/jsonnet-ext-code-libraries?expand=1 now allows transitive dependencies from the `jsonnet_library` without needing to inject them into the calling `jsonnet_to_json` rule.